### PR TITLE
Use setuptools_scm to set version from git tags

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
         twine upload dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install flake8
+        python -m pip install .[tests]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 dist/
 
 venv
+freegs/_version.py

--- a/freegs/__init__.py
+++ b/freegs/__init__.py
@@ -29,7 +29,7 @@ along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-__version__ = "0.7.0"
+from ._version import __version__
 
 from .equilibrium import Equilibrium
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools >= 61.0.0"]
+requires = [
+    "setuptools >= 61.0.0",
+    "setuptools_scm[toml] >= 6.2",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,7 +21,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Physics"
 ]
-version = "0.7.0"
 license = {text = "GNU Lesser General Public License v3 or later (LGPLv3+)"}
 authors = [{name = "Ben Dudson", email = "benjamin.dudson@york.ac.uk"}]
 urls = {project = "https://github.com/freegs-plasma/freegs"}
@@ -29,6 +31,7 @@ dependencies = [
     "h5py>=2.10.0",
     "Shapely>=1.7.1",
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = [
@@ -37,3 +40,9 @@ tests = [
 docs = [
     "sphinx>=3.4,<5",
 ]
+
+[tool.setuptools.dynamic]
+version = { attr = "setuptools_scm.get_version" }
+
+[tool.setuptools_scm]
+write_to = "freegs/_version.py"


### PR DESCRIPTION
See https://github.com/pypa/setuptools_scm

Provided freegs is installed (so not used directly from a local checkout, or via an editable install), the version number will be set from the latest git tag, and include the actual commit hash if not exactly on a tag.