### PR TITLE
Add __getitem__, coil and current setter/getter for Circuit class

### DIFF
--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -98,6 +98,32 @@ class Circuit:
             if label == name:
                 return coil
         raise KeyError("Circuit does not contain coil with label '{0}'".format(name))
+    
+    @property
+    def current(self) -> float:
+        return self._current
+
+    @current.setter
+    def current(self, value: float):
+        """
+        When updating the circuit current, also update the current in the coils in the circuit (with multipliers)
+        """
+        self._current = value
+        for _, coil, multiplier in self.coils:
+            coil.current = multiplier * value
+
+    @property
+    def control(self) -> bool:
+        return self._control
+
+    @control.setter
+    def control(self, value: bool):
+        """
+        When updating the circuit control switch, also update the control switch in the coils in the circuit
+        """
+        self._control = value
+        for _, coil, _ in self.coils:
+            coil.control = value
 
     def psi(self, R, Z):
         """

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -90,6 +90,14 @@ class Circuit:
         self.coils = coils
         self.current = current
         self.control = control
+    
+    def __getitem__(self, name):
+        """Returns a coil in the circuit using circuit[coil_name]"""
+
+        for label, coil, _ in self.coils:
+            if label == name:
+                return coil
+        raise KeyError("Circuit does not contain coil with label '{0}'".format(name))
 
     def psi(self, R, Z):
         """


### PR DESCRIPTION
Adds a __getitem__ method for Circuit, so that you can access coils in the same way as for Machine.

Adds setter and getter routines for coil and current in Circuit, automatically updating the constituent coils to be consistent with the Circuit (this helps particularly when printing out the Circuit)