### PR TITLE
Add freeqdsk to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib>=2.0.0
 h5py>=2.10.0
 Shapely>=1.7.1
 importlib-metadata<4.3,>=1.1.0
+freeqdsk


### PR DESCRIPTION
As reported in: https://github.com/freegs-plasma/freegs/issues/91

I'm not aware of a particular version requirement for freeqdsk, so I didn't specify it in the file.