### PR TITLE
Extract jtor shape function into a class

### DIFF
--- a/01-freeboundary.py
+++ b/01-freeboundary.py
@@ -8,20 +8,28 @@ import freegs
 
 tokamak = freegs.machine.TestTokamak()
 
-eq = freegs.Equilibrium(tokamak=tokamak,
-                        Rmin=0.1, Rmax=2.0,    # Radial domain
-                        Zmin=-1.0, Zmax=1.0,   # Height range
-                        nx=65, ny=65,          # Number of grid points
-                        boundary=freegs.boundary.freeBoundaryHagenow)  # Boundary condition
+eq = freegs.Equilibrium(
+    tokamak=tokamak,
+    Rmin=0.1,
+    Rmax=2.0,  # Radial domain
+    Zmin=-1.0,
+    Zmax=1.0,  # Height range
+    nx=65,
+    ny=65,  # Number of grid points
+    boundary=freegs.boundary.freeBoundaryHagenow,
+)  # Boundary condition
 
 
 #########################################
 # Plasma profiles
 
-profiles = freegs.jtor.ConstrainPaxisIp(eq,
-                                        1e3, # Plasma pressure on axis [Pascals]
-                                        2e5, # Plasma current [Amps]
-                                        2.0) # Vacuum f=R*Bt
+profiles = freegs.jtor.ConstrainPaxisIpArbShape(
+    eq,
+    1e3,  # Plasma pressure on axis [Pascals]
+    2e5,  # Plasma current [Amps]
+    2.0,  # Vacuum f=R*Bt
+    shape_function=freegs.jtor.DoublePowerShapeFunction(alpha_m=1, alpha_n=2),
+)
 
 #########################################
 # Coil current constraints
@@ -29,20 +37,24 @@ profiles = freegs.jtor.ConstrainPaxisIp(eq,
 # Specify locations of the X-points
 # to use to constrain coil currents
 
-xpoints = [(1.1, -0.6),   # (R,Z) locations of X-points
-           (1.1, 0.8)]
+xpoints = [
+    (1.1, -0.6),  # (R,Z) locations of X-points
+    (1.1, 0.8),
+]
 
-isoflux = [(1.1,-0.6, 1.1,0.6)] # (R1,Z1, R2,Z2) pair of locations
+isoflux = [(1.1, -0.6, 1.1, 0.6)]  # (R1,Z1, R2,Z2) pair of locations
 
 constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux)
 
 #########################################
 # Nonlinear solve
 
-freegs.solve(eq,          # The equilibrium to adjust
-             profiles,    # The toroidal current profile function
-             constrain,
-             show=True)   # Constraint function to set coil currents
+freegs.solve(
+    eq,  # The equilibrium to adjust
+    profiles,  # The toroidal current profile function
+    constrain,
+    show=True,
+)  # Constraint function to set coil currents
 
 # eq now contains the solution
 
@@ -80,6 +92,7 @@ constrain.plot(axis=axis, show=True)
 # Safety factor
 
 import matplotlib.pyplot as plt
+
 plt.plot(*eq.q())
 plt.xlabel(r"Normalised $\psi$")
 plt.ylabel("Safety factor")

--- a/docs/creating_equilibria.rst
+++ b/docs/creating_equilibria.rst
@@ -399,13 +399,15 @@ Constrain pressure and current
 One of the most intuitive methods is to fix the shape
 of the plasma profiles, and adjust them to fix the
 pressure on the magnetic axis and total plasma current.
-To do this, create a ``ConstrainPaxisIp`` profile object:
+To do this, create a ``ConstrainBetapIpArbShape`` profile object:
 
 ::
    
-   profiles = freegs.jtor.ConstrainPaxisIp(1e4, # Pressure on axis [Pa]
-                                           1e6, # Plasma current [Amps]
-                                           1.0) # Vacuum f=R*Bt
+   profiles = freegs.jtor.ConstrainBetapIpArbShape(eq,
+                  1e4, # Pressure on axis [Pa]
+                  1e6, # Plasma current [Amps]
+                  1.0, # Vacuum f=R*Bt
+                  shape_function=freegs.jtor.DoublePowerShapeFunction())
 
 
 This sets the toroidal current to:
@@ -415,7 +417,7 @@ This sets the toroidal current to:
    J_\phi = L \left[\beta_0 R + \left(1-\beta_0\right)/R\right] \left(1-\psi_n^{\alpha_m}\right)^{\alpha_n}
 
 where :math:`\psi_n` is the normalised poloidal flux, 0 on the magnetic axis and 1 on the plasma boundary/separatrix.
-The constants which determine the profile shapes are :math:`\alpha_m = 1` and  :math:`\alpha_n = 2`. These can be changed by specifying in the initialisation of ``ConstrainPaxisIp``.
+The constants which determine the profile shapes are :math:`\alpha_m = 1` and  :math:`\alpha_n = 2`. These can be changed by specifying in the initialisation of ``DoublePowerShapeFunction``. Any arbitrary shape function can be passed via the ``shape_function`` argument provided the object complies with the ``ProfileShapeFunction`` interface.
 
 The values of :math:`L` and :math:`\beta_0` are determined from the constraints: The pressure on axis is given by integrating the pressure gradient flux function 
 
@@ -448,11 +450,14 @@ This is the method used in `Y.M.Jeon 2015 <https://arxiv.org/abs/1503.03135>`_, 
 
 ::
    
-   profiles = freegs.jtor.ConstrainBetapIp(0.5, # Poloidal beta
-                                           1e6, # Plasma current [Amps]
-                                           1.0) # Vacuum f=R*Bt
-   
+   profiles = freegs.jtor.ConstrainBetapIpArbShape(eq,
+                  0.5, # Poloidal beta
+                  1e6, # Plasma current [Amps]
+                  1.0, # Vacuum f=R*Bt
+                  shape_function=freegs.jtor.DoublePowerShapeFunction())
+
 By integrating over the plasma domain and combining the constraints on poloidal beta and plasma current, the values of :math:`L` and :math:`\beta_0` are found.
+
 
 Feedback and shape control
 --------------------------

--- a/freegs/jtor.py
+++ b/freegs/jtor.py
@@ -175,8 +175,8 @@ class ConstrainBetapIpArbShape(Profile):
         betap - Poloidal beta
         Ip    - Plasma current [Amps]
         fvac  - Vacuum f = R*Bt
-        shape_function - a callable which accepts a scalar normalised psi and array of alpha.
-        Defaults to `DoublePowerShapeFunction`.
+        shape_function - a callable which accepts a scalar normalised psi.
+                         Defaults to `DoublePowerShapeFunction`.
         Raxis - R used in p' and ff' components
         """
 

--- a/freegs/test_jtor.py
+++ b/freegs/test_jtor.py
@@ -1,25 +1,49 @@
 import numpy as np
+import pytest
 
 from . import jtor
 from . import equilibrium
 
 
-def test_psinorm_range():
+@pytest.mark.parametrize(
+    ("profile_class", "kwargs"),
+    (
+        (jtor.ConstrainPaxisIp, {}),
+        (jtor.ConstrainBetapIp, {}),
+        (jtor.ConstrainPaxisIpArbShape, {}),
+        (jtor.ConstrainBetapIpArbShape, {}),
+        (
+            jtor.ConstrainPaxisIpArbShape,
+            {"shape_function": jtor.DoublePowerShapeFunction()},
+        ),
+        (
+            jtor.ConstrainBetapIpArbShape,
+            {"shape_function": jtor.DoublePowerShapeFunction()},
+        ),
+        (
+            jtor.ConstrainPaxisIpArbShape,
+            {"shape_function": jtor.DoublePowerShapeFunction(1.0, 2.0)},
+        ),
+        (
+            jtor.ConstrainBetapIpArbShape,
+            {"shape_function": jtor.DoublePowerShapeFunction(1.0, 2.0)},
+        ),
+    ),
+)
+def test_psinorm_range(profile_class, kwargs):
     """Test that the profiles produce finite values outside core"""
 
     eq = equilibrium.Equilibrium(Rmin=0.5, Rmax=1.5, Zmin=-1.0, Zmax=1.0, nx=33, ny=33)
 
-    for profiles in [
-        jtor.ConstrainPaxisIp(eq, 1e3, 2e5, 2.0),
-        jtor.ConstrainBetapIp(eq, 1.0, 2e5, 2.0),
-    ]:
-        current_density = profiles.Jtor(eq.R, eq.Z, eq.psi())
-        assert np.all(np.isfinite(current_density))
+    profiles = profile_class(eq, 1e3, 2e5, 2.0, **kwargs)
 
-        assert profiles.pprime(1.0) == 0.0
-        assert profiles.pprime(1.1) == 0.0
-        assert np.isfinite(profiles.pprime(-0.32))
+    current_density = profiles.Jtor(eq.R, eq.Z, eq.psi())
+    assert np.all(np.isfinite(current_density))
 
-        assert profiles.ffprime(1.0) == 0.0
-        assert profiles.ffprime(1.1) == 0.0
-        assert np.isfinite(profiles.ffprime(-0.32))
+    assert profiles.pprime(1.0) == 0.0
+    assert profiles.pprime(1.1) == 0.0
+    assert np.isfinite(profiles.pprime(-0.32))
+
+    assert profiles.ffprime(1.0) == 0.0
+    assert profiles.ffprime(1.1) == 0.0
+    assert np.isfinite(profiles.ffprime(-0.32))


### PR DESCRIPTION
Making available some of the changes that removes the hard-coded double power shape function and allows arbitrary shape functions.

We can now use `ConstrainPaxisIpArbShape` or `ConstrainBetapIpArbShape` to constrain the profiles with an arbitrary `shape_function`. By default, these will use the `DoublePowerShapeFunction` but any class that implements the new `ProfileShapeFunction` interface will work. 

Backwards compatibility ensured by writing the `ConstrainBetapIp` and `ConstrainPaxisIp` classes to point at their arbitrary shape counterpart. 

Added tests using the existing `test_jtor.py` to ensure these additions replicate the behaviour of the code before these changes. 

Example 01 updated to use the new classes but I don't think updating all of the examples will be necessary--let me know your thoughts on this.