### PR TITLE
fixing `__author__` variable in `__init__.py`

### DIFF
--- a/freegs/__init__.py
+++ b/freegs/__init__.py
@@ -47,4 +47,3 @@ from . import plotting
 
 
 __version__ = metadata(__package__)["Version"]
-__author__ = "Ben Dudson <benjamin.dudson@york.ac.uk>"

--- a/freegs/__init__.py
+++ b/freegs/__init__.py
@@ -47,4 +47,4 @@ from . import plotting
 
 
 __version__ = metadata(__package__)["Version"]
-__author__ = metadata(__package__)["Author"]
+__author__ = "Ben Dudson <benjamin.dudson@york.ac.uk>"


### PR DESCRIPTION
Fixing `__author__` in `__init__.py`.

`metadata(__package__)` does not have an `"Author"` key. When this runs the variable `__author__` is set to `None`.

When I run `mypy` on my own package which imports FreeGS it throws an error, despite having the `# type: ignore` flag on when importing `freegs`, see example error:

```terminal
py.test --mypy python/gsfit/database_readers/freegs/setup_bp_probes.py 
================================================================================= test session starts =================================================================================
platform linux -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/peter.buxton/github/gsfit_github
configfile: pyproject.toml
plugins: anyio-4.9.0, dash-3.1.1, xdist-3.8.0, mypy-1.0.1, cov-6.2.1, nbval-0.11.0
collected 2 items / 1 error                                                                                                                                                           

======================================================================================= ERRORS ========================================================================================
______________________________________________________ ERROR collecting python/gsfit/database_readers/freegs/setup_bp_probes.py _______________________________________________________
python/gsfit/database_readers/freegs/setup_bp_probes.py:4: in <module>
    import freegs  # type: ignore
    ^^^^^^^^^^^^^
venv_gsfit_github/lib/python3.13/site-packages/freegs/__init__.py:49: in <module>
    __author__ = metadata(__package__)["Author"]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
venv_gsfit_github/lib/python3.13/site-packages/importlib_metadata/_adapters.py:101: in __getitem__
    raise KeyError(item)
E   KeyError: 'Author'
=============================================================================== short test summary info ===============================================================================
ERROR python/gsfit/database_readers/freegs/setup_bp_probes.py - KeyError: 'Author'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================== 1 error in 1.04s ===================================================================================
```